### PR TITLE
Change hash substring to be 26 characters instead of 20.

### DIFF
--- a/cleverbot.go
+++ b/cleverbot.go
@@ -84,7 +84,7 @@ func (s *Session) Ask(q string) (string, error) {
 	s.values.Set("stimulus", q)
 
 	enc_data := s.values.Encode()
-	digest_txt := enc_data[9:29]
+	digest_txt := enc_data[9:35]
 	tokenMd5 := md5.New()
 	io.WriteString(tokenMd5, digest_txt)
 	tokenbuf := hexDigest(tokenMd5)


### PR DESCRIPTION
Cleverbot released an update that requires the first 26 characters after `stimulus=` in the post body to be hashed for the `incognocheck` parameter. Previously it only required the first 20. Since the update, if you only hash 20 characters, you end up getting 'DENIED' back for the session ID.
